### PR TITLE
Fix py/get_monthly_behavior_uniques.py and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Interactive documentation for the Lotame API is available at https://api.lotame.
 # Warnings
 
 * Generally speaking, the examples are just that, examples. They are not highly robust and secure applications. As just one example of this, some will accept the API username and password as command line arguments, but make no attempt to hide those from operating system process listings, etc...
-* Depending on the configuration and completeness of your local environment you may see "InsecurePlatformWarning"'s when running these scripts, as all HTTP requests use SSL and require a fully functioning SSL environment via urllib3
 
 # License
 
-Copyright (c) 2017 Lotame Solutions, Inc.
+Copyright (c) 2019 Lotame Solutions, Inc.
 
 Published under The MIT License, see LICENSE

--- a/py/get_monthly_behavior_uniques.py
+++ b/py/get_monthly_behavior_uniques.py
@@ -80,6 +80,9 @@ def main():
     valid_months = [str(month) for month in range(1, 13)]
     prompt = 'Enter a month (numeric): '
     month = get_choice(prompt, valid_months)
+    if len(month) == 1:
+        month = f'0{month}'
+
     year = get_choice('Enter a year: ')
     date = f'{year}{month}01'
 


### PR DESCRIPTION
Fixed an issue with py/get_monthly_behavior_uniques that was causing zeroes to come back for single-digit months (the ref_date was getting set incorrectly).

Also updated the readme to set the year as 2019, as well as removing that SSL-related line that I don't believe is relevant anymore.